### PR TITLE
Agregado cierre de conexiones al cerrar server

### DIFF
--- a/database/connection.ts
+++ b/database/connection.ts
@@ -52,3 +52,16 @@ export const executeQuery = (query, params) : Promise<any> => {
   }
 };
 // ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+// Cierre de las conexiones a BD cuando se interrumpe el proceso del server.
+process.on("SIGINT", async() => {
+  console.log("Cerrando conexiones MySQL");
+  if (pool) {
+    await pool.end();
+    console.log("Conexiones cerradas, terminando proceso");
+  }
+  else {
+    console.log("No se detectaron conexiones, terminando proceso");
+  }
+  process.exit(0);
+});


### PR DESCRIPTION
# Cierre de conexiones a BD
Se agregó un event handler para detectar cierre de servidor por un comando de interrupción y garantizar el cierre de conexiones a la base de datos.